### PR TITLE
create auth and todos components

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,9 +1,32 @@
-import React from 'react';
+import React, { useState } from 'react';
+import Navbar from './components/navbar/Navbar';
+import SideDrawer from './components/navbar/SideDrawer/SideDrawer';
+import Backdrop from './components/navbar/Backdrop/Backdrop';
 
 const App: React.FC = () => {
+  const [sideDrawerOpen, setSideDrawerOpen] = useState(false);
+
+  const clickDrawerToggleButtonHandler = () => {
+    setSideDrawerOpen(!sideDrawerOpen);
+  };
+
+  const clickBackdropHandler = () => {
+    setSideDrawerOpen(false);
+  };
+
+  let backdrop;
+  if (sideDrawerOpen) {
+    backdrop = <Backdrop clickBackdrop={clickBackdropHandler} />;
+  }
+
   return (
-    <div className="App">
-      <h1>App.tsx</h1>
+    <div className="App" style={{ height: '100%' }}>
+      <Navbar clickDrawerToggleButton={clickDrawerToggleButtonHandler} />
+      <SideDrawer hasShown={sideDrawerOpen} />
+      {backdrop}
+      <main style={{ marginTop: '64px' }}>
+        <p>This is the page content!</p>
+      </main>
     </div>
   );
 };

--- a/client/src/components/auth/SignIn.tsx
+++ b/client/src/components/auth/SignIn.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-const SignIn: React.FC = () => {
+const SignIn: React.SFC = () => {
   return <h1>SingIn Page</h1>;
 };
 

--- a/client/src/components/auth/SignIn.tsx
+++ b/client/src/components/auth/SignIn.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const SignIn: React.FC = () => {
+  return <h1>SingIn Page</h1>;
+};
+
+export default SignIn;

--- a/client/src/components/auth/SignUp.tsx
+++ b/client/src/components/auth/SignUp.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const SignUp: React.FC = () => {
+  return <h1>SignUp Page</h1>;
+};
+
+export default SignUp;

--- a/client/src/components/auth/SignUp.tsx
+++ b/client/src/components/auth/SignUp.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-const SignUp: React.FC = () => {
+const SignUp: React.SFC = () => {
   return <h1>SignUp Page</h1>;
 };
 

--- a/client/src/components/navbar/Backdrop/Backdrop.css
+++ b/client/src/components/navbar/Backdrop/Backdrop.css
@@ -1,0 +1,9 @@
+.backdrop {
+  position: fixed;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  left: 0;
+  background: rgba(0, 0, 0, 0.3);
+  z-index: 100;
+}

--- a/client/src/components/navbar/Backdrop/Backdrop.tsx
+++ b/client/src/components/navbar/Backdrop/Backdrop.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import './Backdrop.css';
+
+export interface Props {
+  clickBackdrop: () => void;
+}
+
+const Backdrop: React.FC<Props> = ({ clickBackdrop }: Props) => {
+  return <div className="backdrop" role="button" tabIndex={0} onClick={clickBackdrop} onKeyDown={clickBackdrop} />;
+};
+
+export default Backdrop;

--- a/client/src/components/navbar/Backdrop/Backdrop.tsx
+++ b/client/src/components/navbar/Backdrop/Backdrop.tsx
@@ -5,7 +5,7 @@ export interface Props {
   clickBackdrop: () => void;
 }
 
-const Backdrop: React.FC<Props> = ({ clickBackdrop }: Props) => {
+const Backdrop: React.SFC<Props> = ({ clickBackdrop }: Props) => {
   return <div className="backdrop" role="button" tabIndex={0} onClick={clickBackdrop} onKeyDown={clickBackdrop} />;
 };
 

--- a/client/src/components/navbar/DrawerToggleButton.tsx/DrawerToggleButton.css
+++ b/client/src/components/navbar/DrawerToggleButton.tsx/DrawerToggleButton.css
@@ -1,0 +1,22 @@
+.toggle-button {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-around;
+  height: 24px;
+  width: 30px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+.toggle-button:focus {
+  outline: none;
+}
+
+.toggle-button-line {
+  width: 30px;
+  height: 2px;
+  background: #fff;
+}

--- a/client/src/components/navbar/DrawerToggleButton.tsx/DrawerToggleButton.tsx
+++ b/client/src/components/navbar/DrawerToggleButton.tsx/DrawerToggleButton.tsx
@@ -5,7 +5,7 @@ export interface Props {
   clickDrawerToggleButton: () => void;
 }
 
-const DrawerToggleButton: React.FC<Props> = ({ clickDrawerToggleButton }: Props) => {
+const DrawerToggleButton: React.SFC<Props> = ({ clickDrawerToggleButton }: Props) => {
   return (
     <button className="toggle-button" onClick={clickDrawerToggleButton}>
       <div className="toggle-button-line" />

--- a/client/src/components/navbar/DrawerToggleButton.tsx/DrawerToggleButton.tsx
+++ b/client/src/components/navbar/DrawerToggleButton.tsx/DrawerToggleButton.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import './DrawerToggleButton.css';
+
+export interface Props {
+  clickDrawerToggleButton: () => void;
+}
+
+const DrawerToggleButton: React.FC<Props> = ({ clickDrawerToggleButton }: Props) => {
+  return (
+    <button className="toggle-button" onClick={clickDrawerToggleButton}>
+      <div className="toggle-button-line" />
+      <div className="toggle-button-line" />
+      <div className="toggle-button-line" />
+    </button>
+  );
+};
+
+export default DrawerToggleButton;

--- a/client/src/components/navbar/Navbar.css
+++ b/client/src/components/navbar/Navbar.css
@@ -1,0 +1,55 @@
+.navbar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  background: #026aa7;
+  height: 56px;
+}
+
+.navbar-navigation {
+  display: flex;
+  height: 100%;
+  align-items: center;
+  padding: 0 1rem;
+}
+
+.navbar-logo {
+  margin-left: 1rem;
+}
+
+.navbar-logo a {
+  color: #fff;
+  text-decoration: none;
+  font-size: 2rem;
+}
+
+.spacer {
+  flex: 1;
+}
+
+.navbar-navigation-items a {
+  color: #fff;
+  text-decoration: none;
+}
+
+.navbar-navigation-items a:hover,
+.navbar-navigation-items a:active {
+  color: #42526e;
+}
+
+@media (max-width: 768px) {
+  .navbar-navigation-items {
+    display: none;
+  }
+}
+
+@media (min-width: 769px) {
+  .navbar-toggle-button {
+    display: none;
+  }
+
+  .navbar-logo {
+    margin-left: 0;
+  }
+}

--- a/client/src/components/navbar/Navbar.tsx
+++ b/client/src/components/navbar/Navbar.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import DrawerToggleButton from './DrawerToggleButton.tsx/DrawerToggleButton';
+import SignOutLinks from './links/SignOutLinks';
+import SignInLinks from './links/SignInLinks';
+import './Navbar.css';
+
+export interface Props {
+  clickDrawerToggleButton: () => void;
+}
+
+const Navbar: React.FC<Props> = ({ clickDrawerToggleButton }: Props) => {
+  return (
+    <header className="navbar">
+      <nav className="navbar-navigation">
+        <div className="navbar-toggle-button">
+          <DrawerToggleButton clickDrawerToggleButton={clickDrawerToggleButton} />
+        </div>
+        <div className="navbar-logo">
+          <a href="/todos">TODO</a>
+        </div>
+        <div className="spacer" />
+        <div className="navbar-navigation-items">
+          <SignOutLinks />
+          <SignInLinks />
+        </div>
+      </nav>
+    </header>
+  );
+};
+
+export default Navbar;

--- a/client/src/components/navbar/Navbar.tsx
+++ b/client/src/components/navbar/Navbar.tsx
@@ -20,6 +20,7 @@ const Navbar: React.FC<Props> = ({ clickDrawerToggleButton }: Props) => {
         </div>
         <div className="spacer" />
         <div className="navbar-navigation-items">
+          {/* TODO:ログイン状態により表示を切り替えるように修正する */}
           <SignOutLinks />
           <SignInLinks />
         </div>

--- a/client/src/components/navbar/Navbar.tsx
+++ b/client/src/components/navbar/Navbar.tsx
@@ -8,7 +8,7 @@ export interface Props {
   clickDrawerToggleButton: () => void;
 }
 
-const Navbar: React.FC<Props> = ({ clickDrawerToggleButton }: Props) => {
+const Navbar: React.SFC<Props> = ({ clickDrawerToggleButton }: Props) => {
   return (
     <header className="navbar">
       <nav className="navbar-navigation">

--- a/client/src/components/navbar/SideDrawer/SideDrawer.css
+++ b/client/src/components/navbar/SideDrawer/SideDrawer.css
@@ -1,0 +1,52 @@
+.side-drawer {
+  height: 100%;
+  background: white;
+  box-shadow: 1px 0px 7px rgba(0, 0, 0, 0.5);
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 70%;
+  max-width: 400px;
+  z-index: 200;
+  transform: translateX(-100%);
+  transition: transform 0.3s ease-out;
+}
+
+.side-drawer.open {
+  transform: translateX(0);
+}
+
+.side-drawer ul {
+  height: 100%;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+  justify-content: center;
+}
+
+.side-drawer li {
+  display: block;
+  padding: 1rem 0;
+  padding-left: 1rem;
+  border-bottom: thin solid black;
+  color: white;
+  text-decoration: none;
+  font-size: 1.2rem;
+}
+
+.side-drawer li:hover,
+.side-drawer li:active {
+  background: #026aa7;
+}
+
+.side-drawer a {
+  color: #000;
+  text-decoration: none;
+  font-size: 1.2rem;
+}
+
+@media (min-width: 769px) {
+  .side-drawer {
+    display: none;
+  }
+}

--- a/client/src/components/navbar/SideDrawer/SideDrawer.tsx
+++ b/client/src/components/navbar/SideDrawer/SideDrawer.tsx
@@ -6,7 +6,7 @@ export interface Props {
   hasShown: boolean;
 }
 
-const SideDrawer: React.FC<Props> = ({ hasShown }: Props) => {
+const SideDrawer: React.SFC<Props> = ({ hasShown }: Props) => {
   let drawerClasses = 'side-drawer';
   if (hasShown) {
     drawerClasses = 'side-drawer open';

--- a/client/src/components/navbar/SideDrawer/SideDrawer.tsx
+++ b/client/src/components/navbar/SideDrawer/SideDrawer.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import SignInLinks from '../links/SignInLinks';
+import './SideDrawer.css';
+
+export interface Props {
+  hasShown: boolean;
+}
+
+const SideDrawer: React.FC<Props> = ({ hasShown }: Props) => {
+  let drawerClasses = 'side-drawer';
+  if (hasShown) {
+    drawerClasses = 'side-drawer open';
+  }
+
+  return (
+    <nav className={drawerClasses}>
+      <SignInLinks />
+    </nav>
+  );
+};
+
+export default SideDrawer;

--- a/client/src/components/navbar/links/Links.css
+++ b/client/src/components/navbar/links/Links.css
@@ -1,0 +1,10 @@
+.navbar-navigation-items ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+}
+
+.navbar-navigation-items li {
+  padding: 0 0.5rem;
+}

--- a/client/src/components/navbar/links/SignInLinks.tsx
+++ b/client/src/components/navbar/links/SignInLinks.tsx
@@ -1,9 +1,7 @@
 import React from 'react';
 import './Links.css';
 
-export interface Props {}
-
-const SignInLinks: React.SFC<Props> = () => {
+const SignInLinks: React.SFC = () => {
   return (
     <ul>
       <li>

--- a/client/src/components/navbar/links/SignInLinks.tsx
+++ b/client/src/components/navbar/links/SignInLinks.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import './Links.css';
+
+export interface Props {}
+
+const SignInLinks: React.FC<Props> = () => {
+  return (
+    <ul>
+      <li>
+        {/* TODO:後でURL変更 */}
+        <a href="/todos">New Todos</a>
+      </li>
+      <li>
+        <a href="/users/login">Log Out</a>
+      </li>
+    </ul>
+  );
+};
+
+export default SignInLinks;

--- a/client/src/components/navbar/links/SignInLinks.tsx
+++ b/client/src/components/navbar/links/SignInLinks.tsx
@@ -3,7 +3,7 @@ import './Links.css';
 
 export interface Props {}
 
-const SignInLinks: React.FC<Props> = () => {
+const SignInLinks: React.SFC<Props> = () => {
   return (
     <ul>
       <li>

--- a/client/src/components/navbar/links/SignOutLinks.tsx
+++ b/client/src/components/navbar/links/SignOutLinks.tsx
@@ -1,9 +1,7 @@
 import React from 'react';
 import './Links.css';
 
-export interface Props {}
-
-const SignOutLinks: React.SFC<Props> = () => {
+const SignOutLinks: React.SFC = () => {
   return (
     <ul>
       <li>

--- a/client/src/components/navbar/links/SignOutLinks.tsx
+++ b/client/src/components/navbar/links/SignOutLinks.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import './Links.css';
+
+export interface Props {}
+
+const SignOutLinks: React.FC<Props> = () => {
+  return (
+    <ul>
+      <li>
+        <a href="/users/">Sign Up</a>
+      </li>
+      <li>
+        <a href="/users/login">Sign In</a>
+      </li>
+    </ul>
+  );
+};
+
+export default SignOutLinks;

--- a/client/src/components/navbar/links/SignOutLinks.tsx
+++ b/client/src/components/navbar/links/SignOutLinks.tsx
@@ -3,7 +3,7 @@ import './Links.css';
 
 export interface Props {}
 
-const SignOutLinks: React.FC<Props> = () => {
+const SignOutLinks: React.SFC<Props> = () => {
   return (
     <ul>
       <li>

--- a/client/src/components/todos/TodoList.tsx
+++ b/client/src/components/todos/TodoList.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const TodoList: React.FC = () => {
+  return <h1>TodoList Page</h1>;
+};
+
+export default TodoList;

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1,13 +1,10 @@
-body {
-  margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
+html {
+  height: 100%;
 }
 
-code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
-    monospace;
+body {
+  margin: 0;
+  padding: 0;
+  font-family: sans-serif;
+  height: 100%;
 }

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
@@ -19,7 +15,5 @@
     "noEmit": true,
     "jsx": "preserve"
   },
-  "include": [
-    "src"
-  ]
+  "include": ["src"]
 }


### PR DESCRIPTION
**ナビゲーションバーの作成**

画面サイズにより、ナビゲーションバーの表示を切り替える。

**参考**

- サイドバーの作成方法
https://www.youtube.com/watch?v=l6nmysZKHFU
https://qiita.com/roottool/items/89b4adcea8314e5f8e17#%E3%83%8A%E3%83%93%E3%82%B2%E3%83%BC%E3%82%B7%E3%83%A7%E3%83%B3%E3%83%90%E3%83%BC%E3%82%92%E5%AE%9F%E8%A3%85%E3%81%99%E3%82%8B

---

**画面**

- サイドバー非表示時
<img width="775" alt="navbar1" src="https://user-images.githubusercontent.com/42855788/64074276-2660d200-cce4-11e9-8ae9-d0994c70fa23.png">

- サイドバー表示時
<img width="737" alt="navbar2" src="https://user-images.githubusercontent.com/42855788/64074265-05987c80-cce4-11e9-9eca-5050ae821b86.png">
<img width="738" alt="navber3" src="https://user-images.githubusercontent.com/42855788/64074266-07624000-cce4-11e9-9fc9-19ba0b15ccf3.png">

---

レビューよろしくお願いいたします。